### PR TITLE
Add support for Laravel 5.5 - 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 vendor
 build
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "type": "library",
     "require": {
         "fzaninotto/faker": "^1.7",
-        "illuminate/database": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/database": "^5.5|^6.0",
+        "illuminate/support": "^5.5|^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^6.0",
-        "orchestra/testbench" : "~3.5",
-        "orchestra/database": "3.5.*"
+        "phpunit/phpunit" : "^6.0|^7.0|^8.0",
+        "orchestra/testbench" : "^3.5",
+        "orchestra/database": "^3.5|^4.0"
     },
     "autoload": {
         "psr-4" : {

--- a/src/Console/Scrub.php
+++ b/src/Console/Scrub.php
@@ -4,6 +4,7 @@ use Faker\Factory as Faker;
 use Faker\Generator;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 class Scrub extends Command
 {
@@ -54,7 +55,7 @@ class Scrub extends Command
                 return [$field => $fakerKey($this->faker, $record[$field])];
             }
 
-            if (str_contains($fakerKey, ':')) {
+            if (Str::contains($fakerKey, ':')) {
                 $formatter = explode(":", $fakerKey)[0];
                 $arguments = explode(",", explode(":", $fakerKey)[1]);
 

--- a/tests/ScrubTest.php
+++ b/tests/ScrubTest.php
@@ -118,7 +118,10 @@ class ScrubTest extends TestCase
                 public function __invoke($faker, $record)
                 {
                     $this->test->assertInstanceOf(Generator::class, $faker);
-                    $this->test->assertArraySubset($this->user, $record);
+                    $this->test->assertEquals($this->user['id'], $record['id']);
+                    $this->test->assertEquals($this->user['first_name'], $record['first_name']);
+                    $this->test->assertEquals($this->user['last_name'], $record['last_name']);
+                    $this->test->assertEquals($this->user['email'], $record['email']);
 
                     return [
                         'first_name' => 'Foo'
@@ -148,7 +151,10 @@ class ScrubTest extends TestCase
         $this->app['config']['carwash'] = [
             'users' => function ($faker, $record) use ($user) {
                 $this->assertInstanceOf(Generator::class, $faker);
-                $this->assertArraySubset($user, $record);
+                $this->assertEquals($user['id'], $record['id']);
+                $this->assertEquals($user['first_name'], $record['first_name']);
+                $this->assertEquals($user['last_name'], $record['last_name']);
+                $this->assertEquals($user['email'], $record['email']);
 
                 return [
                     'first_name' => 'Foo',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,7 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->setUpDatabase($this->app);


### PR DESCRIPTION
I really like to use this in a Laravel 5.8, and soon to be Laravel 6, application. I updated the version constraints to make sure Laravel 5.5 - 6 can be installed. I also had to fix some deprecations/changes in PHPUnit. Please note that the minimum PHP version to run the tests is now 7.1 because of the `void` return type hint.